### PR TITLE
Improved tooltip when shown above

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ thing! https://github.com/PolymerLabs/tedium/issues
 _[Demo and API docs](https://elements.polymer-project.org/elements/paper-tooltip)_
 
 
-## &lt;paper-tooltip&gt;
+## &lt;kwc-paper-tooltip&gt;
 
 Material design: [Tooltips](https://www.google.com/design/spec/components/tooltips.html)
 
-`<paper-tooltip>` is a label that appears on hover and focus when the user
+`<kwc-paper-tooltip>` is a label that appears on hover and focus when the user
 hovers over an element with the cursor or with the keyboard. It will be centered
 to an anchor element specified in the `for` attribute, or, if that doesn't exist,
 centered to the parent node containing it.
@@ -31,12 +31,12 @@ Example:
 ```html
 <div style="display:inline-block">
   <button>Click me!</button>
-  <paper-tooltip>Tooltip text</paper-tooltip>
+  <kwc-paper-tooltip>Tooltip text</kwc-paper-tooltip>
 </div>
 
 <div>
   <button id="btn">Click me!</button>
-  <paper-tooltip for="btn">Tooltip text</paper-tooltip>
+  <kwc-paper-tooltip for="btn">Tooltip text</kwc-paper-tooltip>
 </div>
 ```
 
@@ -44,8 +44,8 @@ The tooltip can be positioned on the top|bottom|left|right of the anchor using
 the `position` attribute. The default position is bottom.
 
 ```html
-<paper-tooltip for="btn" position="left">Tooltip text</paper-tooltip>
-<paper-tooltip for="btn" position="top">Tooltip text</paper-tooltip>
+<kwc-paper-tooltip for="btn" position="left">Tooltip text</kwc-paper-tooltip>
+<kwc-paper-tooltip for="btn" position="top">Tooltip text</kwc-paper-tooltip>
 ```
 
 ### Styling

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
-  "name": "paper-tooltip",
+  "name": "kwc-paper-tooltip",
   "version": "2.0.0",
-  "description": "Material design tooltip popup for content",
+  "description": "An element to display a tooltip, also above the content",
   "authors": [
     "The Polymer Authors"
   ],
@@ -10,7 +10,7 @@
     "polymer",
     "tooltip"
   ],
-  "main": "paper-tooltip.html",
+  "main": "kwc-paper-tooltip.html",
   "private": true,
   "repository": {
     "type": "git",

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <html lang="en">
 <head>
-  <title>paper-tooltip demo</title>
+  <title>kwc paper-tooltip demo</title>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
@@ -21,7 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../iron-icons/iron-icons.html">
   <link rel="import" href="../../paper-icon-button/paper-icon-button.html">
   <link rel="import" href="../../paper-styles/color.html">
-  <link rel="import" href="../paper-tooltip.html">
+  <link rel="import" href="../kwc-paper-tooltip.html">
   <link rel="import" href="test-button.html">
 
   <custom-style>
@@ -65,10 +65,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <div id="id_4" class="avatar orange" tabindex="0"></div>
 
         <!-- paper-icon-buttons have an inherent padding that will push the tooltip down. offset undoes it -->
-        <paper-tooltip for="id_1" offset="0">&lt;3 &lt;3 &lt;3 </paper-tooltip>
-        <paper-tooltip for="id_2" offset="0">wake up!</paper-tooltip>
-        <paper-tooltip for="id_3" offset="0">help I am trapped in a tooltip</paper-tooltip>
-        <paper-tooltip for="id_4" offset="0">meow!</paper-tooltip>
+        <kwc-paper-tooltip for="id_1" offset="0">&lt;3 &lt;3 &lt;3 </kwc-paper-tooltip>
+        <kwc-paper-tooltip for="id_2" offset="0">wake up!</kwc-paper-tooltip>
+        <kwc-paper-tooltip for="id_3" offset="0">help I am trapped in a tooltip</kwc-paper-tooltip>
+        <kwc-paper-tooltip for="id_4" offset="0">meow!</kwc-paper-tooltip>
       </template>
     </demo-snippet>
 
@@ -78,15 +78,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <!-- Adding a tabindex so that we can show the tooltip when the whole box is tabbed to -->
         <div tabindex="0">
           <input type="checkbox">allosaurus
-          <paper-tooltip>the name means "different lizard"</paper-tooltip>
+          <kwc-paper-tooltip>the name means "different lizard"</kwc-paper-tooltip>
         </div>
         <div tabindex="0">
           <input type="checkbox">brontosaurus
-          <paper-tooltip>the name means "thunder lizard"</paper-tooltip>
+          <kwc-paper-tooltip>the name means "thunder lizard"</kwc-paper-tooltip>
         </div>
         <div tabindex="0">
           <input type="checkbox">megalosaurus
-          <paper-tooltip>the name means "roof lizard"</paper-tooltip>
+          <kwc-paper-tooltip>the name means "roof lizard"</kwc-paper-tooltip>
         </div>
       </div>
       </template>
@@ -100,10 +100,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <div id="dir_3" class="avatar green" tabindex="0"></div>
         <div id="dir_4" class="avatar orange" tabindex="0"></div>
 
-        <paper-tooltip for="dir_1" position="left" animation-delay="0">👈</paper-tooltip>
-        <paper-tooltip for="dir_2" position="right" animation-delay="0">👉</paper-tooltip>
-        <paper-tooltip for="dir_3" position="top" animation-delay="0">👍</paper-tooltip>
-        <paper-tooltip for="dir_4" position="bottom" animation-delay="0">👎</paper-tooltip>
+        <kwc-paper-tooltip for="dir_1" position="left" animation-delay="0">👈</kwc-paper-tooltip>
+        <kwc-paper-tooltip for="dir_2" position="right" animation-delay="0">👉</kwc-paper-tooltip>
+        <kwc-paper-tooltip for="dir_3" position="top" animation-delay="0">👍</kwc-paper-tooltip>
+        <kwc-paper-tooltip for="dir_4" position="bottom" animation-delay="0">👎</kwc-paper-tooltip>
       </template>
     </demo-snippet>
 
@@ -112,7 +112,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <template>
         <custom-style>
           <style is="custom-style">
-            paper-tooltip.custom img {
+            kwc-paper-tooltip.custom img {
               width: 80px;
               padding-right: 10px;
               float: left;
@@ -125,10 +125,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </style>
         </custom-style>
         <paper-icon-button id="demo4_icon1" icon="favorite" alt="heart"></paper-icon-button>
-        <paper-tooltip for="demo4_icon1" class="custom" animation-delay="0">
+        <kwc-paper-tooltip for="demo4_icon1" class="custom" animation-delay="0">
           <img src="./donuts.png">
           Rich-text tooltips are doable but against the Material Design spec.
-        </paper-tooltip>
+        </kwc-paper-tooltip>
       </template>
     </demo-snippet>
 
@@ -136,9 +136,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <demo-snippet class="centered-demo">
       <template>
         <paper-icon-button id="demo5_icon1" icon="all-out" alt="clock" on-click="onClick"></paper-icon-button>
-        <paper-tooltip id="demo5_tooltip" for="demo5_icon1" animation-delay="500" animation-entry="scale-up-animation" animation-exit="scale-down-animation">
+        <kwc-paper-tooltip id="demo5_tooltip" for="demo5_icon1" animation-delay="500" animation-entry="scale-up-animation" animation-exit="scale-down-animation">
           This grows rather than fades in
-        </paper-tooltip>
+        </kwc-paper-tooltip>
       </template>
     </demo-snippet>
     
@@ -161,9 +161,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <button id="demo6_btn_starthide">Start Animation Hide</button>
         <button id="demo6_btn_cancel">Animation Cancel</button>
         <paper-icon-button id="demo6_icon1" icon="schedule" alt="clock" on-click="onClick"></paper-icon-button>
-        <paper-tooltip id="demo6_tooltip" for="demo6_icon1" class="slowmo" animation-delay="500">
+        <kwc-paper-tooltip id="demo6_tooltip" for="demo6_icon1" class="slowmo" animation-delay="500">
           Slow Motion Load - Click to complete straight away
-        </paper-tooltip>
+        </kwc-paper-tooltip>
         <script>
           demo6_btn_startshow.addEventListener('click',function() {
             demo6_tooltip.playAnimation("entry");

--- a/demo/test-button.html
+++ b/demo/test-button.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../../iron-icons/iron-icons.html">
-<link rel="import" href="../paper-tooltip.html">
+<link rel="import" href="../kwc-paper-tooltip.html">
 
 <dom-module id="test-button">
   <template>
@@ -26,7 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </style>
 
     <paper-icon-button id="m" icon="menu" alt="menu"></paper-icon-button>
-    <paper-tooltip for="m" offset="8">hot dogs</paper-tooltip>
+    <kwc-paper-tooltip for="m" offset="8">hot dogs</kwc-paper-tooltip>
   </template>
 
   <script>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-  <title>paper-tooltip</title>
+  <title>kwc-paper-tooltip</title>
 
   <script src="../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../iron-component-page/iron-component-page.html">

--- a/kwc-paper-tooltip.d.ts
+++ b/kwc-paper-tooltip.d.ts
@@ -160,5 +160,5 @@ interface PaperTooltipElement extends Polymer.Element {
 }
 
 interface HTMLElementTagNameMap {
-  "paper-tooltip": PaperTooltipElement;
+  "kwc-paper-tooltip": PaperTooltipElement;
 }

--- a/kwc-paper-tooltip.html
+++ b/kwc-paper-tooltip.html
@@ -53,7 +53,7 @@ Custom property | Description | Default
 @demo demo/index.html
 -->
 
-<dom-module id="paper-tooltip">
+<dom-module id="kwc-paper-tooltip">
   <template>
     <style>
       :host {
@@ -79,6 +79,12 @@ Custom property | Description | Default
         padding: 8px;
         border-radius: 2px;
         @apply --paper-tooltip;
+      }
+
+      #tooltip[above] ::slotted(.triangle){
+          transform: rotate(180deg);
+          top: auto !important;
+          bottom: -8px;
       }
 
       @keyframes keyFrameScaleUp {
@@ -226,14 +232,14 @@ Custom property | Description | Default
       }
     </style>
 
-    <div id="tooltip" class="hidden">
+    <div id="tooltip" class="hidden" above$="{{above}}">
       <slot></slot>
     </div>
   </template>
 
   <script>
     Polymer({
-      is: 'paper-tooltip',
+      is: 'kwc-paper-tooltip',
       hostAttributes: {
         role: 'tooltip',
         tabindex: -1
@@ -314,9 +320,17 @@ Custom property | Description | Default
          * animationConfig settings.  You can enter your own animation
          * by setting it to the css class name.
          */
-        animationExit: {
+         animationExit: {
           type: String,
           value: ""
+        },
+        /**
+         * The flag that indicate if the tooltip
+         * must shown above or not
+         */
+         above: {
+          type: Boolean,
+          value: false
         },
         /**
          * This property is deprecated.  Use --paper-tooltip-animation to change the animation.
@@ -518,9 +532,13 @@ Custom property | Description | Default
           }
           // Clip the top/bottom side.
           if (parentRect.top + tooltipTop + thisRect.height > window.innerHeight) {
-            this.style.bottom = parentRect.height + 'px';
-            this.style.top = 'auto';
+            this.above = true;
+
+            this.style.top = Math.max(-parentRect.top, tooltipTop) - (142 + thisRect.height) + 'px';
+            this.style.bottom = 'auto';
           } else {
+            this.above = false;
+
             this.style.top = Math.max(-parentRect.top, tooltipTop) + 'px';
             this.style.bottom = 'auto';
           }

--- a/test/basic.html
+++ b/test/basic.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>paper-tooltip tests</title>
+  <title>kwc paper-tooltip tests</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
@@ -20,7 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
   <link rel="import" href="../../test-fixture/test-fixture.html">
-  <link rel="import" href="../paper-tooltip.html">
+  <link rel="import" href="../kwc-paper-tooltip.html">
   <link rel="import" href="test-button.html">
   <link rel="import" href="test-icon.html">
 
@@ -35,7 +35,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     height: 20px;
     background-color: red;
   }
-  paper-tooltip {
+  kwc-paper-tooltip {
     width: 70px;
     height: 30px;
     /*
@@ -64,7 +64,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div>
         <div id="target"></div>
-        <paper-tooltip for="target" animation-delay="0">Tooltip text</paper-tooltip>
+        <kwc-paper-tooltip for="target" animation-delay="0">Tooltip text</kwc-paper-tooltip>
       </div>
     </template>
   </test-fixture>
@@ -73,7 +73,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div>
         <div id="target" style="position:absolute"></div>
-        <paper-tooltip for="target" class="wide" fit-to-visible-bounds>Tooltip text</paper-tooltip>
+        <kwc-paper-tooltip for="target" class="wide" fit-to-visible-bounds>Tooltip text</kwc-paper-tooltip>
       </div>
     </template>
   </test-fixture>
@@ -82,7 +82,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div>
         <div id="target"></div>
-        <paper-tooltip for="target"></paper-tooltip>
+        <kwc-paper-tooltip for="target"></kwc-paper-tooltip>
       </div>
     </template>
   </test-fixture>
@@ -91,7 +91,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div>
         <div id="target"></div>
-        <paper-tooltip>Tooltip text</paper-tooltip>
+        <kwc-paper-tooltip>Tooltip text</kwc-paper-tooltip>
       </div>
     </template>
   </test-fixture>
@@ -112,7 +112,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div>
         <div id="target"></div>
-        <paper-tooltip for="target" animation-delay="0" hidden></paper-tooltip>
+        <kwc-paper-tooltip for="target" animation-delay="0" hidden></kwc-paper-tooltip>
       </div>
     </template>
   </test-fixture>
@@ -121,7 +121,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div>
         <div id="target"></div>
-        <paper-tooltip for="target" manual-mode>Text</paper-tooltip>
+        <kwc-paper-tooltip for="target" manual-mode>Text</kwc-paper-tooltip>
       </div>
     </template>
   </test-fixture>
@@ -140,7 +140,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('tooltip is shown when target is focused', function() {
         var f = fixture('no-text');
         var target = f.querySelector('#target');
-        var tooltip = f.querySelector('paper-tooltip');
+        var tooltip = f.querySelector('kwc-paper-tooltip');
 
         var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
         assert.isTrue(isHidden(actualTooltip));
@@ -152,7 +152,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('tooltip is not shown if empty', function() {
         var f = fixture('basic');
         var target = f.querySelector('#target');
-        var tooltip = f.querySelector('paper-tooltip');
+        var tooltip = f.querySelector('kwc-paper-tooltip');
 
         var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
         assert.isTrue(isHidden(actualTooltip));
@@ -164,7 +164,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('tooltip responds to playAnimation and cancelAnimation', function() {
           var f = fixture('basic');
           var target = f.querySelector('#target');
-          var tooltip = f.querySelector('paper-tooltip');
+          var tooltip = f.querySelector('kwc-paper-tooltip');
 
           var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
           assert.isTrue(isHidden(actualTooltip));
@@ -183,7 +183,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('tooltip doesn\'t throw an exception if it has no offsetParent', function() {
         var f = fixture('no-offset-parent');
         var target = f.querySelector('#target');
-        var tooltip = f.querySelector('paper-tooltip');
+        var tooltip = f.querySelector('kwc-paper-tooltip');
 
         var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
         assert.isTrue(isHidden(actualTooltip));
@@ -197,7 +197,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('tooltip is positioned correctly (bottom)', function() {
         var f = fixture('basic');
         var target = f.querySelector('#target');
-        var tooltip = f.querySelector('paper-tooltip');
+        var tooltip = f.querySelector('kwc-paper-tooltip');
 
         var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
         assert.isTrue(isHidden(actualTooltip));
@@ -227,7 +227,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('tooltip is positioned correctly (top)', function() {
         var f = fixture('basic');
         var target = f.querySelector('#target');
-        var tooltip = f.querySelector('paper-tooltip');
+        var tooltip = f.querySelector('kwc-paper-tooltip');
         tooltip.position = 'top';
 
         var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
@@ -258,7 +258,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('tooltip is positioned correctly (right)', function() {
         var f = fixture('basic');
         var target = f.querySelector('#target');
-        var tooltip = f.querySelector('paper-tooltip');
+        var tooltip = f.querySelector('kwc-paper-tooltip');
         tooltip.position = 'right';
 
         var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
@@ -289,7 +289,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('tooltip is positioned correctly (left)', function() {
         var f = fixture('basic');
         var target = f.querySelector('#target');
-        var tooltip = f.querySelector('paper-tooltip');
+        var tooltip = f.querySelector('kwc-paper-tooltip');
         tooltip.position = 'left';
 
         var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
@@ -320,7 +320,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('tooltip is fitted correctly if out of bounds', function() {
         var f = fixture('fitted');
         var target = f.querySelector('#target');
-        var tooltip = f.querySelector('paper-tooltip');
+        var tooltip = f.querySelector('kwc-paper-tooltip');
         target.style.top = 0;
         target.style.left = 0;
 
@@ -341,7 +341,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('tooltip is positioned correctly after being dynamically set', function() {
         var f = fixture('dynamic');
         var target = f.querySelector('#target');
-        var tooltip = f.querySelector('paper-tooltip');
+        var tooltip = f.querySelector('kwc-paper-tooltip');
 
         var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
         assert.isTrue(isHidden(actualTooltip));
@@ -376,7 +376,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('tooltip is hidden after target is blurred', function() {
         var f = fixture('basic');
         var target = f.querySelector('#target');
-        var tooltip = f.querySelector('paper-tooltip');
+        var tooltip = f.querySelector('kwc-paper-tooltip');
 
         var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
         assert.isTrue(isHidden(actualTooltip));
@@ -394,7 +394,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('tooltip unlistens to target on detach', function(done) {
         var f = fixture('basic');
         var target = f.querySelector('#target');
-        var tooltip = f.querySelector('paper-tooltip');
+        var tooltip = f.querySelector('kwc-paper-tooltip');
 
         sinon.spy(tooltip, 'show');
 
@@ -417,7 +417,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('tooltip ignores events in manual-mode', function() {
         var f = fixture('manual-mode');
 
-        var tooltip = f.querySelector('paper-tooltip');
+        var tooltip = f.querySelector('kwc-paper-tooltip');
         assert.isTrue(tooltip.manualMode);
 
         tooltip.show();
@@ -440,7 +440,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('changing manual-mode toggles event listeners', function() {
         var f = fixture('manual-mode');
 
-        var tooltip = f.querySelector('paper-tooltip');
+        var tooltip = f.querySelector('kwc-paper-tooltip');
         assert.isTrue(tooltip.manualMode);
 
         sinon.spy(tooltip, '_addListeners');
@@ -459,7 +459,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('changing for= re-targets event listeners', function() {
         var f = fixture('dynamic');
-        var tooltip = f.querySelector('paper-tooltip');
+        var tooltip = f.querySelector('kwc-paper-tooltip');
 
         sinon.spy(tooltip, '_addListeners');
         sinon.spy(tooltip, '_removeListeners');
@@ -565,7 +565,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     suite('a11y', function() {
       test('has aria role "tooltip"', function() {
         var f = fixture('basic');
-        var tooltip = f.querySelector('paper-tooltip');
+        var tooltip = f.querySelector('kwc-paper-tooltip');
 
         assert.isTrue(tooltip.getAttribute('role') == 'tooltip');
       });

--- a/test/index.html
+++ b/test/index.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 --><html><head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-  <title>paper-tooltip tests</title>
+  <title>kwc paper-tooltip tests</title>
   <script src="../../web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/test-button.html
+++ b/test/test-button.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../paper-tooltip.html">
+<link rel="import" href="../kwc-paper-tooltip.html">
 
 <dom-module id="test-button">
   <template>
@@ -24,7 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         background-color: red;
       }
 
-      paper-tooltip {
+      kwc-paper-tooltip {
         width: 70px;
         height: 30px;
       }
@@ -32,7 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </style>
 
     <div id="button"></div>
-    <paper-tooltip id="buttonTooltip" for="button">Tooltip text</paper-tooltip>
+    <kwc-paper-tooltip id="buttonTooltip" for="button">Tooltip text</kwc-paper-tooltip>
   </template>
 
   <script>

--- a/test/test-icon.html
+++ b/test/test-icon.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../paper-tooltip.html">
+<link rel="import" href="../kwc-paper-tooltip.html">
 
 <dom-module id="test-icon">
   <template>
@@ -24,7 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         background-color: red;
       }
 
-      paper-tooltip {
+      kwc-paper-tooltip {
         width: 70px;
         height: 30px;
       }
@@ -32,7 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </style>
 
     <div id="icon"></div>
-    <paper-tooltip id="iconTooltip" for="icon"><slot></slot></paper-tooltip>
+    <kwc-paper-tooltip id="iconTooltip" for="icon"><slot></slot></kwc-paper-tooltip>
   </template>
 
   <script>


### PR DESCRIPTION
I opened this PR to solve the problem related to the tooltips in Kano World, since if you wanted to display a tooltip of a badge at the bottom of the page there was a bug and the tooltip went up to the top of the page without being displayed.
This is a problem that comes out of the fact that the `paper-tooltip` component requires an **offsetParent** which is `kwc-badge-listing`, but so doing what it returns is always **1200px**.

The solutions were mainly two:

1) Reverse or otherwise rewrite the layout of the page, which would take a long time.

2) Create a 'Kano' component, so we can modify everything to our liking without upsetting anything else. Furthermore it will be possible to use it as a component already ready in other projects without having to be careful if it is correctly displayed when there is too little space at the bottom.

I chose road number 2 both for a question of timing, and for a question of portability and reusability of the code.